### PR TITLE
docs: add agent shell/runtime decision gate

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,17 +3,32 @@
 This file tracks active and proposed work items with GitHub issue linkage.
 
 ## P1 (Current)
-1. Recurring reminders release gate and rollout
+1. Agent shell/runtime decision gate
+   - Status: In progress
+   - Outcome target: Choose Claude App, GPT app, or managed agent as the next user-facing/runtime path while preserving the existing Schoology core functions.
+   - Core functions to preserve:
+     - Schoology refresh/scrape and login/session handling.
+     - Assignment normalization and stable identity.
+     - Manual statuses, notes, reminders/tasks, and pending confirmations.
+     - Daily summaries and reminder delivery.
+     - Dashboard health/status visibility.
+     - Deterministic app-executed tool actions.
+     - Local/server state ownership unless explicitly migrated.
+   - Acceptance gate:
+     - Short decision memo compares Claude App, GPT app, and managed agent.
+     - Memo identifies selected path, rejected alternatives, migration steps, and rollback plan.
+     - Parity checklist covers refresh, summary, reminders, status updates, notes, dashboard health, and failure alerts.
+2. Recurring reminders release gate and rollout
    - Status: In progress
    - Outcome target: Complete beta reset, story suite, one-pass GPT-5.2 judge evidence, user UAT, and production rollout.
    - Acceptance gate:
      - `scripts/reset_beta_from_prod_memory.ps1` report artifact produced.
      - Agentic story suite artifacts produced.
      - One GPT-5.2 judge JSON artifact produced with required stories passing.
-2. OpenClaw beta UAT and production promotion readiness
+3. OpenClaw beta UAT and production promotion readiness
    - Status: In progress
    - Outcome target: Confirm parity for refresh/chat/reminders and complete a low-risk production cutover checklist.
-3. Dashboard Phase 1 — foundation polish
+4. Dashboard Phase 1 — foundation polish
    - Status: In progress
    - Design reference: `docs/DASHBOARD_DESIGN.md` Phase 1
    - Items:
@@ -21,14 +36,14 @@ This file tracks active and proposed work items with GitHub issue linkage.
      b. Course color stripes on assignment rows (left border, hashed from course name)
      c. Mobile bottom tab bar (replaces hidden sidebar on ≤ 860px)
      d. System status dot in Tonight right column (green/amber/red, links to system panel)
-4. #14 DB-backed context compaction and long-thread memory
+5. #14 DB-backed context compaction and long-thread memory
    - Status: Open
    - Outcome target: Long chats retain critical context with bounded token use.
-5. #15 Detail-page fallback for ambiguous submission status
+6. #15 Detail-page fallback for ambiguous submission status
    - Status: Open
    - Outcome target: Submission state classification remains accurate when list view is ambiguous.
    - Known ambiguity: title suffixes like `(Graded: <date>)` may describe assignment-level timing and are not reliable proof that the current student's work is graded/resolved.
-6. #10 Auto-cancel reminders for inactive/resolved assignments
+7. #10 Auto-cancel reminders for inactive/resolved assignments
    - Status: Open
    - Outcome target: Assignment-linked reminders do not fire after item becomes inactive.
 
@@ -51,9 +66,9 @@ This file tracks active and proposed work items with GitHub issue linkage.
 5. Scheduled auto-update task decision
    - Status: Not yet filed
    - Outcome target: Decide manual-only vs scheduled update path.
-6. Agents SDK evaluation
+6. Provider/SDK follow-through after agent shell/runtime decision
    - Status: Not yet filed
-   - Outcome target: Decision memo on staying with current architecture vs adopting SDK.
+   - Outcome target: Implement selected provider/runtime path without weakening the deterministic Schoology tool boundary.
 7. Cross-project rollout of the agentic release pattern
    - Status: Not yet filed
    - Outcome target: Reuse beta reset + story gate + judge evidence flow in other repos as a standard release template.
@@ -67,6 +82,7 @@ This file tracks active and proposed work items with GitHub issue linkage.
 6. #13 Completed in code: capability registry + planner/agent guardrails.
 7. Dashboard redesign (2026-03-15): sidebar nav, metric row, 2-column home layout shipped to prod. All 111 tests pass.
 8. Schoology title derivation (2026-03-15): clean display names for no-link Schoology rows shipped to prod.
+9. Agent shell/runtime choice elevated to P1 (2026-05-17): choose Claude App, GPT app, or managed agent before further wrapper/runtime promotion.
 
 ## Planning Governance
 - Canonical backlog lives on `main`.
@@ -79,4 +95,3 @@ This file tracks active and proposed work items with GitHub issue linkage.
 1. Local server migration off laptop runtime
    - Status: Completed (2026-02-18)
    - Outcome: Production runtime now runs on local server Docker with persistent data and health checks.
-

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # Roadmap
 
 ## Goal
-Run a reliable Schoology assistant on the local server that refreshes assignments, keeps actionable status clean, and delivers clear daily/reminder updates via Telegram.
+Run a reliable Schoology assistant on the local server that refreshes assignments, keeps actionable status clean, and delivers clear daily/reminder updates via Telegram while preserving the core Schoology workflow as the agent shell/runtime is evaluated.
 
 ## Current Decisions
 - Login uses Mayari username and password directly.
@@ -15,13 +15,15 @@ Run a reliable Schoology assistant on the local server that refreshes assignment
 - Incoming Telegram messages are batched briefly and the oldest dropped if too long.
 - Agent tool routing uses a multi-step structured-output planner (tool group -> tool picker -> augment).
 - Tool execution is handled by app code (not model tool-calling).
+- Product boundary: preserve core functions regardless of agent shell/runtime choice: Schoology refresh/scrape, assignment normalization, manual statuses, notes, reminders/tasks, daily summaries, dashboard health, deterministic tool execution, local state, and Telegram delivery until intentionally replaced.
+- Next strategic decision: choose the default agent shell/runtime path before further wrapper/runtime promotion: Claude App, GPT app, or managed agent.
 - Availability target: run via Docker with restart policy + health check; update with `docker compose -p schoology-prod up -d --build`.
 - Production runtime is hosted on the local server (Docker Compose).
 - If using Twilio later, use Auth Token for now; plan to switch to API Key for server move.
 - Session-based login: use one-time interactive login and refresh when session expires.
 - Add Telegram alert when re-authentication is required.
 - Daily summary lists only unresolved items (Missing, Incomplete, Not completed/submitted, Absent).
-- Agent model choice: GPT-5.2 (not mini or pro).
+- Current production agent model choice: GPT-5.2 (not mini or pro); the upcoming runtime decision may change the app shell and/or provider, but not the core Schoology tool boundary.
 - Maintain offline unit + E2E tests using fixtures (no live Schoology needed).
 - Daily summary includes tasks scheduled for today.
 - One-time tasks roll over by 24 hours if not completed.
@@ -60,14 +62,36 @@ Run a reliable Schoology assistant on the local server that refreshes assignment
   - Reminder-scope release gate completed for this wave: `npm run beta:reset-memory`, `npm run stories:run`, `npm run stories:judge`, prod rebuild, and beta/prod dashboard health checks.
   - Full dashboard design plan written (`docs/DASHBOARD_DESIGN.md`): user stories, navigation architecture, view designs, interaction patterns, mobile layout, and implementation phases.
 - In progress:
+  - Agent shell/runtime decision: choose Claude App, GPT app, or managed agent while preserving the existing Schoology core functions and deterministic tool boundary.
   - Dashboard Phase 1 polish: sidebar nav fix, course color stripes, mobile bottom tab bar.
   - OpenClaw cron bootstrap reliability (`openclaw_cron_sync`) still relies on runtime retries/log validation rather than deterministic integration coverage.
 
+## Agent Shell/Runtime Decision Gate (Next Step)
+Choose the default user-facing agent shell/runtime before further promotion of the OpenClaw beta path or a new Telegram wrapper. The decision should compare:
+
+1. Claude App path
+   - Can it preserve the current parent-facing workflow with minimal custom runtime surface?
+   - Can it call the Schoology tool boundary safely through MCP/tool API or another deterministic bridge?
+2. GPT app path
+   - Can it preserve the current Telegram/dashboard experience or replace it with an acceptable GPT-native surface?
+   - Can it retain reliable scheduled summaries, reminders, and local/server state?
+3. Managed agent path
+   - Can it run long-lived or scheduled Schoology workflows without weakening credential/session handling?
+   - Does it reduce runtime burden enough to justify added platform coupling?
+
+Decision requirements:
+- Preserve core functions listed in Current Decisions.
+- Keep Schoology actions deterministic and app-executed; the model may plan, but code performs writes.
+- Keep local/server data ownership unless an explicit migration decision is made.
+- Require parity checks for refresh, summary, reminders, status updates, notes, dashboard health, and failure alerts.
+- Produce a short decision memo with selected path, rejected alternatives, migration steps, and rollback plan.
+
 ## Active Queue (P1)
-1. OpenClaw beta UAT and production promotion readiness.
-2. Dashboard Phase 1: sidebar nav fix, course color stripes, mobile bottom tab bar, system status dot in right column.
-3. OpenClaw cron bootstrap hardening and explicit test coverage.
-4. Login/session resilience follow-up while keeping secrets-based unattended login (#18) parked unless strategy changes.
+1. Agent shell/runtime decision gate: choose Claude App, GPT app, or managed agent while preserving core Schoology functions.
+2. OpenClaw beta UAT and production promotion readiness.
+3. Dashboard Phase 1: sidebar nav fix, course color stripes, mobile bottom tab bar, system status dot in right column.
+4. OpenClaw cron bootstrap hardening and explicit test coverage.
+5. Login/session resilience follow-up while keeping secrets-based unattended login (#18) parked unless strategy changes.
 
 ## Ready Next (P2)
 1. Dashboard Phase 2: This Week view (calendar strip + day-lane layout).
@@ -75,7 +99,7 @@ Run a reliable Schoology assistant on the local server that refreshes assignment
 3. Dashboard Phase 4: Command palette (⌘K).
 4. OpenClaw upstream sync SOP (what to pull, how to validate, when to promote).
 5. Scheduled auto-update task decision (Windows Task Scheduler).
-6. Agents SDK evaluation versus current direct Responses architecture.
+6. Provider/SDK follow-through after agent shell/runtime decision.
 7. Extend the agentic release pattern to other projects and templates.
 
 ## Later (P3)


### PR DESCRIPTION
## Summary
- Elevates the next planning step to choosing between Claude App, GPT app, or managed agent.
- Adds explicit guardrails to preserve core Schoology functions regardless of selected shell/runtime.
- Updates both ROADMAP and BACKLOG so the decision is visible in strategic direction and active queue.

## Notes
- No runtime/code changes.
- Follow-up should produce a short decision memo comparing the three options, selected path, migration steps, and rollback plan.