### PR TITLE
docs: decide agent runtime path and accelerator spike

### DIFF
--- a/docs/AGENT_RUNTIME_DECISION.md
+++ b/docs/AGENT_RUNTIME_DECISION.md
@@ -1,0 +1,225 @@
+# Agent Runtime Decision Memo
+
+## Objective
+Choose the next user-facing agent shell/runtime path for the Schoology assistant while preserving the core product functions that already work.
+
+The decision is not only about model quality. It is also about which path gives the fastest safe development loop, the least runtime burden, the clearest operational model, and the lowest risk of weakening Schoology-specific behavior.
+
+## Core Functions That Must Not Regress
+Any selected path must preserve these functions:
+
+- Schoology refresh/scrape and login/session handling.
+- Assignment normalization and stable identity.
+- Manual statuses, notes, reminders/tasks, and pending confirmations.
+- Daily summaries and reminder delivery.
+- Dashboard health/status visibility.
+- Deterministic app-executed tool actions.
+- Local/server state ownership unless explicitly migrated.
+- Clear failure alerts when login, scrape, delivery, or runtime health breaks.
+
+## Current Architecture Baseline
+Current production remains a local/server Docker runtime with:
+
+- Schoology scraper/scheduler.
+- SQLite-backed assignment/task/reminder/chat state.
+- Telegram delivery and chat agent.
+- Dashboard.
+- Deterministic tool runner.
+- Offline test and story-gate coverage.
+
+The existing OpenClaw beta path is a useful comparator because it already separates a gateway/channel layer from the Schoology tool API. It should not be promoted by inertia; it should be compared against the other runtime options.
+
+## Options Compared
+
+### Option A: Claude App Path
+Use Claude-oriented interfaces for the user-facing or developer-facing shell, potentially through Claude Code, MCP, or a Claude-compatible tool bridge.
+
+Strengths:
+- Strong fit for codebase work and iterative development.
+- Good comparator for local-tool and MCP-oriented workflows.
+- Could pair well with a deterministic Schoology tool boundary.
+
+Risks:
+- May bias the product toward a developer assistant rather than a parent-facing Schoology assistant.
+- Production scheduling, reminders, and dashboard state still need the existing local/server runtime or an equivalent service.
+- Direct replacement of the Telegram/dashboard experience may be awkward unless the bridge is clean.
+
+Best use:
+- Developer acceleration and runtime comparison.
+- Possible user shell only if the Schoology tool boundary remains deterministic and parity is proven.
+
+### Option B: GPT App Path
+Continue centering the workflow around ChatGPT/GitHub as the planning and implementation surface, with the Schoology runtime preserved and a provider/runtime abstraction added where needed.
+
+Strengths:
+- This chat already has GitHub visibility and can update the repo directly.
+- Strong fit for product planning plus implementation tracking.
+- If paired with a safe development feedback loop, this may become the fastest iteration path.
+- Least disruptive to current Schoology runtime if implemented as an outer workflow rather than a rewrite.
+
+Risks:
+- Local validation still needs a bridge or user-mediated loop.
+- A GPT-native app surface may not replace Telegram delivery/reminders without extra product work.
+- Could create confusion if ChatGPT is used for development orchestration while the production assistant remains Telegram-based.
+
+Best use:
+- Near-term implementation path.
+- Planning, repo updates, decision records, and supervised development loop.
+- Production runtime can remain local/server + Telegram until a replacement proves parity.
+
+### Option C: Managed Agent Path
+Move some portion of the assistant into a managed agent environment that can run longer-lived tasks, call tools, and reduce local orchestration burden.
+
+Strengths:
+- Could reduce custom runtime burden if scheduling, execution, and tool access are reliable.
+- Potentially useful for long-running evaluation, maintenance, or repo automation.
+- May simplify some agent supervision workflows.
+
+Risks:
+- Schoology credential/session handling is sensitive and currently local/server-bound.
+- Managed runtimes may weaken control over local state, dashboard integration, and live browser session reuse.
+- Scheduled summaries/reminders and production-grade failure handling still require careful parity validation.
+- Migration cost may be high relative to the near-term benefit.
+
+Best use:
+- Later-stage comparator or auxiliary worker path.
+- Not the default production migration target until local state, credentials, scheduling, and parity are solved.
+
+## Implementation Accelerator Options
+Implementation acceleration is a first-class decision factor. A faster feedback loop may matter more than moving production runtime.
+
+### Candidate 1: GitHub-Mediated Feedback Loop
+Use GitHub as the auditable relay between this planning/implementation chat and the dev environment.
+
+Strengths:
+- Already available in this chat.
+- Auditable, branch-scoped, and recoverable.
+- Keeps production runtime untouched.
+- Can start as validation-only.
+
+Risks:
+- Slower than a direct live bridge.
+- Requires a local helper process or user-mediated step.
+- Needs strict approval and output controls.
+
+Best use:
+- First accelerator spike.
+
+### Candidate 2: OpenClaw Gateway
+Use the existing OpenClaw beta direction as the channel/tool gateway for development feedback and possibly user runtime.
+
+Strengths:
+- Already represented in the repo.
+- Aligned with gateway/channel separation.
+- Could support a broader personal-assistant architecture.
+
+Risks:
+- More moving parts than a narrow feedback loop.
+- May become a platform migration instead of a targeted accelerator.
+- Needs renewed parity validation before promotion.
+
+Best use:
+- Comparator and possible medium-term gateway path.
+
+### Candidate 3: MCP-Style Bridge
+Expose a narrow set of Schoology/dev capabilities through an MCP-style boundary.
+
+Strengths:
+- Clean tool boundary.
+- Compatible with multiple agent shells over time.
+- Helps avoid coupling the core to any one provider.
+
+Risks:
+- Access path from this chat may not be available without an intermediate host or connector.
+- Security model must be explicit.
+- Could be overbuilt for the first spike.
+
+Best use:
+- Medium-term abstraction after the first feedback-loop spike proves value.
+
+### Candidate 4: Managed-Agent Alternative
+Use a managed agent environment for validation and implementation support instead of building a local feedback bridge.
+
+Strengths:
+- Could provide built-in long-running execution and stateful sessions.
+- May reduce local helper complexity.
+
+Risks:
+- Might not see the same local runtime, credentials, browser state, or Docker environment.
+- May move too much of the workflow away from the working local/server setup.
+
+Best use:
+- Comparator against the GitHub-mediated feedback loop.
+
+## Recommendation
+Recommended next path:
+
+1. Preserve the current Schoology production runtime.
+2. Continue on the GPT app / ChatGPT + GitHub path for planning and implementation.
+3. Add a small, safe implementation-accelerator spike centered on an auditable feedback loop.
+4. Treat Claude App and managed agent as comparators, not immediate production targets.
+5. Do not promote OpenClaw beta or replace Telegram until parity is proven against the core functions.
+
+Rationale:
+
+- The current Schoology product value is in deterministic workflow execution, not the chat shell itself.
+- A safe feedback loop from this planning chat to local validation could materially accelerate development without moving production runtime.
+- Managed agents may be useful later, but they introduce platform coupling before the key parity questions are settled.
+- Claude-oriented tooling remains valuable as a benchmark and possible developer accelerator, but it should not drive a production rewrite by default.
+
+## Migration Plan
+
+### Phase 1: Decision and Boundary Clarification
+- Keep this memo as the decision record for the branch.
+- Confirm the core function parity checklist.
+- Identify the minimum provider/runtime abstraction needed without rewriting the Schoology core.
+- Decide whether the first accelerator spike uses GitHub relay, OpenClaw gateway, MCP-style bridge, or managed-agent alternative.
+
+### Phase 2: Implementation Accelerator Spike
+- Start with a validation-only loop.
+- Keep production Schoology actions gated behind explicit approval.
+- Store requests/results in an auditable location.
+- Redact and bound returned output.
+- Compare speed and reliability against the current user-mediated flow.
+
+### Phase 3: Provider/Runtime Abstraction
+- Keep tool execution inside app code.
+- Add or clarify model-provider boundaries only where needed.
+- Preserve Telegram and dashboard behavior until a replacement has parity.
+
+### Phase 4: Runtime Choice Follow-Through
+- If GPT path wins, continue local/server production and use the feedback loop for development acceleration.
+- If Claude path wins, connect Claude tooling through the same deterministic tool boundary.
+- If managed agent wins, migrate only after a production parity and rollback plan exists.
+
+## Parity Checklist
+Before promoting any runtime or shell replacement, verify:
+
+- Refresh Schoology.
+- Build daily summary.
+- Deliver daily summary.
+- Create reminder.
+- Update reminder.
+- Complete reminder/task.
+- Update assignment status.
+- Add assignment note.
+- Preserve pending confirmation behavior.
+- Preserve ignored/pending/actionable bucket behavior.
+- Preserve submitted-but-ungraded handling.
+- Show dashboard health.
+- Alert on login/session failure.
+- Alert on scrape or delivery failure.
+- Run offline tests and story gate.
+
+## Rollback Plan
+- Keep current production Docker + Telegram runtime as the rollback target.
+- Do not migrate data ownership until a separate migration decision is approved.
+- Keep OpenClaw beta, managed agent, or any new shell isolated from production unless explicitly promoted.
+- For any provider/runtime spike, preserve the ability to return to the existing GPT-5.2 Telegram agent path.
+
+## Open Questions
+- What is the minimum useful feedback loop that materially accelerates this ChatGPT/GitHub workflow?
+- Can the accelerator remain validation-only at first?
+- Does Claude tooling provide a better local feedback loop than the GPT path?
+- Which parts of the OpenClaw beta should be retained as reusable gateway lessons even if OpenClaw is not promoted?
+- What is the exact threshold for replacing Telegram versus keeping it as the parent-facing interface?

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,7 @@ This file tracks active and proposed work items with GitHub issue linkage.
 1. Agent shell/runtime decision gate
    - Status: In progress
    - Outcome target: Choose Claude App, GPT app, or managed agent as the next user-facing/runtime path while preserving the existing Schoology core functions.
+   - Include implementation acceleration as a decision factor: evaluate whether the current ChatGPT/GitHub workflow can support a safe, auditable development feedback loop that speeds validation while preserving approvals and runtime boundaries.
    - Core functions to preserve:
      - Schoology refresh/scrape and login/session handling.
      - Assignment normalization and stable identity.
@@ -17,18 +18,33 @@ This file tracks active and proposed work items with GitHub issue linkage.
    - Acceptance gate:
      - Short decision memo compares Claude App, GPT app, and managed agent.
      - Memo identifies selected path, rejected alternatives, migration steps, and rollback plan.
+     - Memo includes an implementation-acceleration recommendation and explains whether it changes the selected path.
      - Parity checklist covers refresh, summary, reminders, status updates, notes, dashboard health, and failure alerts.
-2. Recurring reminders release gate and rollout
+2. Implementation accelerator evaluation
+   - Status: In progress
+   - Outcome target: Decide whether to add a safe, auditable feedback loop between this planning/implementation chat and the development environment to accelerate validation.
+   - Candidate paths:
+     - GitHub-mediated request/result workflow.
+     - Existing OpenClaw gateway path.
+     - MCP-style bridge if an accessible host/client path is available.
+     - Managed-agent alternative.
+   - Guardrails:
+     - Default-deny policy with explicit approved operations.
+     - Human approval for production-impacting or credential/session-sensitive work.
+     - Structured request/result records with audit history.
+     - Redacted and bounded outputs.
+     - No production Schoology action without explicit approval.
+3. Recurring reminders release gate and rollout
    - Status: In progress
    - Outcome target: Complete beta reset, story suite, one-pass GPT-5.2 judge evidence, user UAT, and production rollout.
    - Acceptance gate:
      - `scripts/reset_beta_from_prod_memory.ps1` report artifact produced.
      - Agentic story suite artifacts produced.
      - One GPT-5.2 judge JSON artifact produced with required stories passing.
-3. OpenClaw beta UAT and production promotion readiness
+4. OpenClaw beta UAT and production promotion readiness
    - Status: In progress
    - Outcome target: Confirm parity for refresh/chat/reminders and complete a low-risk production cutover checklist.
-4. Dashboard Phase 1 — foundation polish
+5. Dashboard Phase 1 — foundation polish
    - Status: In progress
    - Design reference: `docs/DASHBOARD_DESIGN.md` Phase 1
    - Items:
@@ -36,14 +52,14 @@ This file tracks active and proposed work items with GitHub issue linkage.
      b. Course color stripes on assignment rows (left border, hashed from course name)
      c. Mobile bottom tab bar (replaces hidden sidebar on ≤ 860px)
      d. System status dot in Tonight right column (green/amber/red, links to system panel)
-5. #14 DB-backed context compaction and long-thread memory
+6. #14 DB-backed context compaction and long-thread memory
    - Status: Open
    - Outcome target: Long chats retain critical context with bounded token use.
-6. #15 Detail-page fallback for ambiguous submission status
+7. #15 Detail-page fallback for ambiguous submission status
    - Status: Open
    - Outcome target: Submission state classification remains accurate when list view is ambiguous.
    - Known ambiguity: title suffixes like `(Graded: <date>)` may describe assignment-level timing and are not reliable proof that the current student's work is graded/resolved.
-7. #10 Auto-cancel reminders for inactive/resolved assignments
+8. #10 Auto-cancel reminders for inactive/resolved assignments
    - Status: Open
    - Outcome target: Assignment-linked reminders do not fire after item becomes inactive.
 
@@ -83,6 +99,7 @@ This file tracks active and proposed work items with GitHub issue linkage.
 7. Dashboard redesign (2026-03-15): sidebar nav, metric row, 2-column home layout shipped to prod. All 111 tests pass.
 8. Schoology title derivation (2026-03-15): clean display names for no-link Schoology rows shipped to prod.
 9. Agent shell/runtime choice elevated to P1 (2026-05-17): choose Claude App, GPT app, or managed agent before further wrapper/runtime promotion.
+10. Implementation accelerator added to decision gate (2026-05-17): evaluate safe feedback-loop options before choosing runtime path.
 
 ## Planning Governance
 - Canonical backlog lives on `main`.

--- a/docs/GITHUB_MEDIATED_FEEDBACK_LOOP.md
+++ b/docs/GITHUB_MEDIATED_FEEDBACK_LOOP.md
@@ -1,0 +1,65 @@
+# GitHub-Mediated Feedback Loop Spike
+
+## Decision
+Use a GitHub-mediated feedback loop as the first implementation accelerator spike.
+
+This is the selected first path because it uses capabilities already available in the current workflow: the assistant can update the repository and PR, while the local development environment can inspect the same branch and return validation results through GitHub.
+
+Claude App, OpenClaw gateway, MCP-style bridge, and managed-agent options remain comparators, but they should not block this narrower proof.
+
+## Goal
+Prove that planning and implementation can move faster when validation results from the local development environment are returned to the assistant in an auditable, structured way.
+
+The spike is validation-only. It does not change production Schoology behavior.
+
+## Initial Scope
+The first pass should support only safe development validation, such as:
+
+- Test-suite result summaries.
+- Story-suite result summaries.
+- Static repo/status checks.
+- Dashboard or service health snapshots from a non-production context.
+- Human-approved diagnostic summaries.
+
+## Explicit Non-Goals
+- No production Schoology actions.
+- No credential or session handling changes.
+- No automatic production deployment.
+- No replacement of Telegram, dashboard, Docker runtime, or current local/server state ownership.
+- No broad autonomous execution.
+
+## Proposed Workflow
+1. Assistant updates the implementation branch with a requested validation checkpoint or PR comment.
+2. User or local helper runs the approved validation locally.
+3. The result is posted back to the PR, issue, or repo as a structured summary.
+4. Assistant reads the result and continues the implementation loop.
+5. If this reduces manual handoff, automate the local side in a later phase.
+
+## First Proof Target
+The first proof should answer:
+
+- Can the assistant request a validation checkpoint from the PR context?
+- Can the local side return a compact pass/fail summary without manual reformatting?
+- Can the assistant use that result to decide the next implementation step?
+- Is the loop meaningfully faster than ad hoc manual copy/paste?
+
+## Safety Model
+- Validation-only first.
+- Human approval before any production-impacting or credential/session-sensitive action.
+- Keep request/result records in GitHub so the loop is auditable.
+- Keep results compact and redact sensitive values.
+- Keep production Schoology runtime isolated unless a separate promotion decision is made.
+
+## Acceptance Criteria
+- A PR or issue-based validation request format is documented.
+- At least one validation result is returned through GitHub.
+- The assistant can read and act on the result.
+- The decision memo is updated if the accelerator changes the preferred runtime path.
+
+## Recommended First Manual Trial
+Use PR #26 as the first trial.
+
+Assistant requests a validation checkpoint in the PR.
+User/local environment runs the approved validation.
+User/local environment posts a compact result back to PR #26.
+Assistant reads the PR result and updates the plan or implementation branch accordingly.

--- a/docs/IMPLEMENTATION_ACCELERATOR_SPIKE.md
+++ b/docs/IMPLEMENTATION_ACCELERATOR_SPIKE.md
@@ -1,0 +1,107 @@
+# Implementation Accelerator Spike
+
+## Purpose
+Evaluate whether the development loop can be accelerated by giving the planning assistant a safe way to request local validation work and receive structured results back, without changing production Schoology behavior.
+
+This spike is intentionally narrow. It is not a production runtime migration and it is not a replacement for the Schoology assistant. It is a way to test whether repo planning, code changes, local validation, and result review can happen with less manual handoff.
+
+## Baseline Assumption
+The current production runtime remains the rollback target:
+
+- Docker-based Schoology scheduler and Telegram agent.
+- Local/server state in the existing data directory.
+- Deterministic app-executed tool actions.
+- Dashboard health visibility.
+- Existing beta and story-gate validation patterns.
+
+## Spike Hypothesis
+If a bounded feedback loop can safely return local validation results to the planning assistant, then the GPT app / ChatGPT + GitHub path may remain the fastest near-term implementation path while Claude App and managed-agent options remain comparators.
+
+## Candidate Feedback Paths
+
+### 1. GitHub-Mediated Feedback Path
+Use GitHub as the shared audit trail for validation requests and results.
+
+Why evaluate first:
+- The assistant can already update and inspect GitHub.
+- The repo branch provides natural scoping.
+- Requests and results are reviewable and recoverable.
+- It avoids exposing the production runtime directly.
+
+Expected first use:
+- Validation-only development checks.
+- No production Schoology action.
+- No credential/session handling.
+
+### 2. OpenClaw Gateway Path
+Reuse lessons from the OpenClaw beta gateway and Schoology tool API split.
+
+Why evaluate:
+- It already exists in this repo as a beta architecture direction.
+- It may provide a reusable gateway/channel model.
+
+Concern:
+- It may be more platform migration than minimal accelerator.
+
+### 3. MCP-Style Bridge
+Expose a narrow capability surface through an MCP-style boundary if a reliable host/client access path exists.
+
+Why evaluate:
+- Clean tool boundary.
+- Potentially compatible with more than one agent shell.
+
+Concern:
+- It may require more setup before proving the basic feedback-loop value.
+
+### 4. Managed-Agent Alternative
+Compare whether a managed agent environment can provide the same acceleration without a local feedback bridge.
+
+Why evaluate:
+- It may support long-running implementation or validation tasks.
+
+Concern:
+- It may not share the same local environment, browser state, data, or Docker runtime.
+
+## Scope for First Pass
+The first pass should prove only the following:
+
+1. A validation request can be created in an auditable place.
+2. The local/dev side can process the request under a narrow policy.
+3. The result can be returned in a structured format.
+4. The assistant can inspect the result and continue planning or implementation.
+5. The workflow is faster or clearer than manual handoff.
+
+## Out of Scope for First Pass
+- Production Schoology writes.
+- Credential or session handling changes.
+- Replacing Telegram.
+- Replacing the dashboard.
+- Replacing Docker production runtime.
+- Broad autonomous execution.
+
+## Safety Requirements
+- Start validation-only.
+- Require explicit user approval for anything production-impacting.
+- Keep request and result history auditable.
+- Keep outputs bounded and redact sensitive values.
+- Keep the production Schoology stack isolated from the accelerator until a separate promotion decision is made.
+- Preserve human review before any runtime migration.
+
+## Proposed First Milestone
+Create a minimal proof that can answer:
+
+- Can this assistant request a local validation check through the chosen relay?
+- Can the local environment return a clear pass/fail result?
+- Can the result be reviewed from this chat without manual copy/paste?
+- Did the loop save enough time to justify continuing?
+
+## Success Criteria
+- A documented feedback path is selected for the first implementation attempt.
+- A validation-only loop is proven or rejected.
+- The result is captured in the repo or PR discussion.
+- The agent runtime decision memo is updated if the accelerator changes the preferred path.
+
+## Decision Impact
+If the feedback loop works well, prefer the GPT app / ChatGPT + GitHub path for near-term implementation while preserving the current production runtime.
+
+If the feedback loop is too slow or brittle, compare Claude App and managed-agent paths more aggressively as implementation accelerators rather than only as production runtime alternatives.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,7 @@ Run a reliable Schoology assistant on the local server that refreshes assignment
 - Tool execution is handled by app code (not model tool-calling).
 - Product boundary: preserve core functions regardless of agent shell/runtime choice: Schoology refresh/scrape, assignment normalization, manual statuses, notes, reminders/tasks, daily summaries, dashboard health, deterministic tool execution, local state, and Telegram delivery until intentionally replaced.
 - Next strategic decision: choose the default agent shell/runtime path before further wrapper/runtime promotion: Claude App, GPT app, or managed agent.
+- Implementation accelerator is part of the strategic decision: evaluate whether this ChatGPT/GitHub workflow can support a safe, auditable feedback loop with the dev environment that speeds validation while preserving approvals, auditability, and runtime boundaries.
 - Availability target: run via Docker with restart policy + health check; update with `docker compose -p schoology-prod up -d --build`.
 - Production runtime is hosted on the local server (Docker Compose).
 - If using Twilio later, use Auth Token for now; plan to switch to API Key for server move.
@@ -63,6 +64,7 @@ Run a reliable Schoology assistant on the local server that refreshes assignment
   - Full dashboard design plan written (`docs/DASHBOARD_DESIGN.md`): user stories, navigation architecture, view designs, interaction patterns, mobile layout, and implementation phases.
 - In progress:
   - Agent shell/runtime decision: choose Claude App, GPT app, or managed agent while preserving the existing Schoology core functions and deterministic tool boundary.
+  - Implementation accelerator evaluation: determine whether a safe, auditable dev feedback loop can materially speed implementation enough to influence the runtime choice.
   - Dashboard Phase 1 polish: sidebar nav fix, course color stripes, mobile bottom tab bar.
   - OpenClaw cron bootstrap reliability (`openclaw_cron_sync`) still relies on runtime retries/log validation rather than deterministic integration coverage.
 
@@ -75,19 +77,22 @@ Choose the default user-facing agent shell/runtime before further promotion of t
 2. GPT app path
    - Can it preserve the current Telegram/dashboard experience or replace it with an acceptable GPT-native surface?
    - Can it retain reliable scheduled summaries, reminders, and local/server state?
+   - Does the existing ChatGPT/GitHub workflow offer a faster implementation loop if paired with an auditable dev feedback path?
 3. Managed agent path
    - Can it run long-lived or scheduled Schoology workflows without weakening credential/session handling?
    - Does it reduce runtime burden enough to justify added platform coupling?
+   - Does it offer more acceleration than a lighter dev feedback path while preserving the same runtime guardrails?
 
 Decision requirements:
 - Preserve core functions listed in Current Decisions.
 - Keep Schoology actions deterministic and app-executed; the model may plan, but code performs writes.
 - Keep local/server data ownership unless an explicit migration decision is made.
 - Require parity checks for refresh, summary, reminders, status updates, notes, dashboard health, and failure alerts.
-- Produce a short decision memo with selected path, rejected alternatives, migration steps, and rollback plan.
+- Evaluate implementation acceleration as a first-class factor, including GitHub relay, OpenClaw gateway, MCP-style options, and managed-agent alternatives.
+- Produce a short decision memo with selected path, rejected alternatives, migration steps, rollback plan, and implementation-acceleration recommendation.
 
 ## Active Queue (P1)
-1. Agent shell/runtime decision gate: choose Claude App, GPT app, or managed agent while preserving core Schoology functions.
+1. Agent shell/runtime decision gate: choose Claude App, GPT app, or managed agent while preserving core Schoology functions and evaluating implementation-accelerator options.
 2. OpenClaw beta UAT and production promotion readiness.
 3. Dashboard Phase 1: sidebar nav fix, course color stripes, mobile bottom tab bar, system status dot in right column.
 4. OpenClaw cron bootstrap hardening and explicit test coverage.


### PR DESCRIPTION
## Summary
- Adds the agent runtime decision memo comparing Claude App, GPT app, and managed agent paths.
- Updates roadmap/backlog to treat implementation acceleration as a first-class decision factor.
- Preserves the current Schoology runtime as the baseline while evaluating safe acceleration options.

## Notes
- Planning/docs only so far.
- Follow-up on this branch will add the implementation accelerator spike plan before execution.